### PR TITLE
Allow homepage to be blank

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
   validates :email, presence: true, format: { with: /\A[^@]+@[^@]+\Z/ }, uniqueness: true
   validates :password, presence: true, length: { minimum: 6 }
   validates :self_introduction, length: { maximum: 500 }
-  validates :homepage, format: { with: /^https?:\/\/.*$/, multiline: true }
+  validates :homepage, format: { with: /^https?:\/\/.*$/, multiline: true }, allow_blank: true
 end


### PR DESCRIPTION
プロフィール編集で、ホームページ記載欄が空のときに保存できなかった。