### PR TITLE
Fix file_watcher

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   # Use letter opener
   config.action_mailer.delivery_method = :letter_opener_web
-  
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -52,5 +52,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
ログに大量の警告が流れていたので修正。

```
        ** ERROR: directory is already being watched! **

        Directory: /usr/local/Cellar/groff/1.22.3

        is already being watched through: /usr/local/Cellar/groff/1.22.3

        MORE INFO: https://github.com/guard/listen/wiki/Duplicate-directory-errors
```

## 原因

このエラー自身はlisten がシンボリックリンクをたどって同じディレクトリを見ると起きるエラーの模様。
admin の engine をgemfileに入れたときから起きるようになっていた。

## 対応
listen でなく、ポーリング形式に変更。
