### PR TITLE
Add word-break-all class(css)

### DIFF
--- a/admin/app/views/admin/redirection_logs/index.html.erb
+++ b/admin/app/views/admin/redirection_logs/index.html.erb
@@ -23,12 +23,12 @@
     <tbody>
       <% @redirection_logs.each do |redirection_log| %>
         <tr>
-          <td><%= redirection_log.id %></td>
-          <td><%= redirection_log.created_at %></td>
-          <td><%= redirection_log.to %></td>
-          <td><%= redirection_log.referer %></td>
-          <td><%= redirection_log.user_agent %></td>
-          <td><%= redirection_log.remote_ip %></td>
+          <td class="word-break-all"><%= redirection_log.id %></td>
+          <td class="word-break-all"><%= redirection_log.created_at %></td>
+          <td class="word-break-all"><%= redirection_log.to %></td>
+          <td class="word-break-all"><%= redirection_log.referer %></td>
+          <td class="word-break-all"><%= redirection_log.user_agent %></td>
+          <td class="word-break-all"><%= redirection_log.remote_ip %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -1,0 +1,3 @@
+.word-break-all {
+  word-break: break-all;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
 // "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
 @import "bootstrap-sprockets";
 @import "bootstrap";
+
+@import "./common";


### PR DESCRIPTION
リダイレクトしたログを表示したときに、テーブルに収まらずはみ出してしまったので、どこでも折れるようなCSSを追加した。