### PR TITLE
Simplify capybara settings

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,20 +1,9 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do |example|
-    Capybara.session_name = example.metadata[:driver] || :default
-    args = []
-    args += %w(headless disable-gpu no-sandbox) if ENV["TEST_WITH_GUI_BROWSER"].blank?
-    case example.metadata[:driver]
-    when :mobile, :iphone
-      args += [
-        "window-size=375,667",
-        "user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
-      ]
-      configure_chrome_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: args, w3c: false })
-      driven_by :selenium, using: :chrome, options: { desired_capabilities: configure_chrome_capabilities }, screen_size: [375, 667]
-    else
-      args += ["window-size=1024,768"]
-      configure_chrome_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: args, w3c: false })
-      driven_by :selenium, using: :chrome, options: { desired_capabilities: configure_chrome_capabilities }, screen_size: [1024, 768]
-    end
+    Capybara.session_name = :default
+    args = ['window-size=1024,768']
+    args += %w[headless disable-gpu no-sandbox] if ENV['TEST_WITH_GUI_BROWSER'].blank?
+    configure_chrome_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: args, w3c: false })
+    driven_by :selenium, using: :chrome, options: { desired_capabilities: configure_chrome_capabilities }, screen_size: [1024, 768]
   end
 end


### PR DESCRIPTION
スマホ・PCで特に出し分けなどしていないことと、このアプリはブラウザの複数のセッションで不具合を試すものなのでした。
無駄にスマホ用の設定を入れてしまったので削除します。