### PR TITLE
Use session_id

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,3 +16,16 @@ def in_browser(name)
 
   Capybara.session_name = old_session
 end
+
+def cookie_value_from(name)
+  cookies = page.driver.browser.manage.all_cookies
+  cookie = cookies.find { |c| c[:name] == name }
+  cookie && cookie[:value]
+end
+
+def add_cookie(name, value)
+  page.driver.browser.manage.add_cookie(
+    name: name,
+    value: value.to_s
+  )
+end


### PR DESCRIPTION
セッションハイジャックやセッション固定化攻撃をテストするにあたって、ブラウザのクッキーにあるセッションIDが必要です。
ですが、デフォルトの状態だと、テスト環境ではセッションIDが記録されていませんでした。

config.action_controller.allow_forgery_protectionを有効にして、セッションIDが記録されるようにします。
また、クッキーの値の取得や設定を行うヘルパーも追加します。

## 参考
- https://railsguides.jp/configuring.html
- https://blog.willnet.in/entry/2018/07/04/225558
